### PR TITLE
27 implement script launching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
-
 all: clean
 	@cabal run glados -- $(ARGS)
 
 test: clean
-	@cabal run test
+	@cabal test --test-show-details=direct
 
 clean:
 	@rm -f *.tix;

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+
+all: clean
+	@cabal run glados -- $(ARGS)
+
+test: clean
+	@cabal run test
+
+clean:
+	@rm -f *.tix;

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -9,12 +9,19 @@ import System.Console.GetOpt
 
 import System.Environment
 import System.Exit
+import Data.Maybe (fromMaybe)
+
+getFileName :: [String] -> Maybe FilePath -> String
+getFileName [] b = fromMaybe "stdin" b
+getFileName (x:xs) b = x
 
 main :: IO ()
 main = do
-    -- Parse args
-    (res,fs) <- getArgs >>= parse
-    print res
-    -- print files
-    -- For the time being since we don't know how to pass args with cabal
-    -- we use tokenizeFile immediately
+    -- Parsing arguments
+    (res, fls) <- getArgs >>= parse
+
+    let fileName = getFileName fls (file res)
+    print ("Execute file: " ++  fileName)
+    if (==) fileName "stdin"
+        then exitSuccess -- interactive
+        else exitSuccess -- normal

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,16 +5,16 @@ import Parsing
 import Parsing.Token
 import Parsing.Cpt
 import Parsing.Args
+import System.Console.GetOpt
+
+import System.Environment
+import System.Exit
 
 main :: IO ()
 main = do
     -- Parse args
-    parsedArgs <- parseArgs
-
+    (res,fs) <- getArgs >>= parse
+    print res
+    -- print files
     -- For the time being since we don't know how to pass args with cabal
     -- we use tokenizeFile immediately
-
-    tokenizedcode <- tokenizeFile "./TestFiles/sample1.scm"
-
-    print tokenizedcode
-    print (parseTokenList tokenizedcode)

--- a/lib/Parsing/Args.hs
+++ b/lib/Parsing/Args.hs
@@ -4,11 +4,15 @@ import System.Console.GetOpt
 import System.IO ( hPutStrLn, stderr )
 import Data.Maybe (fromMaybe)
 
+
+-- to access: (key name) (var name)
+-- for example with Record called A we want to access field "file"
+-- let filename = file A
 data Options = Options {
-    file    :: Maybe FilePath,
-    help    :: Bool,
-    debug   :: Bool
-} deriving  Show
+    file  :: Maybe FilePath,
+    help  :: Bool,
+    debug :: Bool
+} deriving  (Show, Eq)
 
 defaultOptions :: Options
 defaultOptions = Options {
@@ -16,7 +20,6 @@ defaultOptions = Options {
     help       = False,
     debug      = False
 }
-
 
 options :: [OptDescr (Options -> Options)]
 options =
@@ -29,7 +32,7 @@ options =
 parse :: [String] -> IO (Options, [String])
 parse argv =
     case getOpt Permute options argv of
-        (o,n,[]  ) -> do
+        (o,n,[]) -> do
             if "-h" `elem` argv
                 then do 
                     hPutStrLn stderr (usageInfo header options)

--- a/lib/Parsing/Args.hs
+++ b/lib/Parsing/Args.hs
@@ -8,20 +8,20 @@ import Data.Maybe (fromMaybe)
 -- to access: (key name) (var name)
 -- for example with Record called A we want to access field "file"
 -- let filename = file A
-data Options = Options {
+data Args = Args {
     file  :: Maybe FilePath,
     help  :: Bool,
     debug :: Bool
 } deriving  (Show, Eq)
 
-defaultOptions :: Options
-defaultOptions = Options {
+defaultOptions :: Args
+defaultOptions = Args {
     file       = Nothing,
     help       = False,
     debug      = False
 }
 
-options :: [OptDescr (Options -> Options)]
+options :: [OptDescr (Args -> Args)]
 options =
     [
         Option ['f'] ["file"]  (OptArg ((\ f opts -> opts { file = Just f }) . fromMaybe "stdin") "FILE") "The FILE that is to be executed.",
@@ -29,7 +29,7 @@ options =
         Option ['d'] ["debug"] (NoArg (\ opts -> opts { debug = True })) "Enter debug mode"
     ]
 
-parse :: [String] -> IO (Options, [String])
+parse :: [String] -> IO (Args, [String])
 parse argv =
     case getOpt Permute options argv of
         (o,n,[]) -> do

--- a/test/Parsing/ArgsTests.hs
+++ b/test/Parsing/ArgsTests.hs
@@ -1,20 +1,40 @@
 module Parsing.ArgsTests where
 
-import Parsing
-import Parsing.Args
-import Test.Tasty
-import Test.Tasty.HUnit
+import           Parsing
+import           Parsing.Args
+import           Test.Tasty
+import           Test.Tasty.HUnit
 
--- parseArgsTest :: [String] -> ParsedArgs -> String-> TestTree
--- parseArgsTest arr restest testName = testCase testName $ do
---     res <- parseArgs' arr 0 (ParsedArgs False "")
---     restest @=? res
+parseArgsTest :: [String] -> Options -> [String] -> String-> TestTree
+parseArgsTest arr restest nonargs testName = testCase testName $ do
+    (res,fs) <- parse arr
+    restest @=? res
+    nonargs @=? fs
 
--- argsSuite :: TestTree
--- argsSuite = testGroup "Parsing.Args Test Suite" [
---         parseArgsTest ["binaryName", "", ""] (ParsedArgs False "") "Empty Args",
---         parseArgsTest ["binaryName"] (ParsedArgs False "") "No Args",
---         parseArgsTest ["binaryName", "-h"] (ParsedArgs True "") "Only -h",
---         parseArgsTest ["binaryName", "filename"] (ParsedArgs False "filename") "Only filename",
---         parseArgsTest ["binaryName", "filename", "-h"] (ParsedArgs True "filename") "File with -h"
---     ]
+argsSuite :: TestTree
+argsSuite = testGroup "Parsing.Args Test Suite" [
+        parseArgsTest [] Options {
+            file       = Nothing,
+            help       = False,
+            debug      = False
+        } [] "Empty Args",
+        parseArgsTest ["filename"] Options {
+            file       = Nothing,
+            help       = False,
+            debug      = False
+        } ["filename"] "File via non flag params",
+        parseArgsTest ["filename", "-d"]  Options {
+            file       = Nothing,
+            help       = False,
+            debug      = True
+        } ["filename"] "Short debug flag",
+        parseArgsTest ["--file=filename"] Options {
+            file       = Just "filename",
+            help       = False,
+            debug      = False
+        } [] "Filename via flag",
+        parseArgsTest ["--debug"] Options {
+            file       = Nothing,
+            help       = False,
+            debug      = True
+        } [] "Long debug flag"    ]

--- a/test/Parsing/ArgsTests.hs
+++ b/test/Parsing/ArgsTests.hs
@@ -5,7 +5,7 @@ import           Parsing.Args
 import           Test.Tasty
 import           Test.Tasty.HUnit
 
-parseArgsTest :: [String] -> Options -> [String] -> String-> TestTree
+parseArgsTest :: [String] -> Args -> [String] -> String-> TestTree
 parseArgsTest arr restest nonargs testName = testCase testName $ do
     (res,fs) <- parse arr
     restest @=? res
@@ -13,27 +13,27 @@ parseArgsTest arr restest nonargs testName = testCase testName $ do
 
 argsSuite :: TestTree
 argsSuite = testGroup "Parsing.Args Test Suite" [
-        parseArgsTest [] Options {
+        parseArgsTest [] Args {
             file       = Nothing,
             help       = False,
             debug      = False
         } [] "Empty Args",
-        parseArgsTest ["filename"] Options {
+        parseArgsTest ["filename"] Args {
             file       = Nothing,
             help       = False,
             debug      = False
         } ["filename"] "File via non flag params",
-        parseArgsTest ["filename", "-d"]  Options {
+        parseArgsTest ["filename", "-d"]  Args {
             file       = Nothing,
             help       = False,
             debug      = True
         } ["filename"] "Short debug flag",
-        parseArgsTest ["--file=filename"] Options {
+        parseArgsTest ["--file=filename"] Args {
             file       = Just "filename",
             help       = False,
             debug      = False
         } [] "Filename via flag",
-        parseArgsTest ["--debug"] Options {
+        parseArgsTest ["--debug"] Args {
             file       = Nothing,
             help       = False,
             debug      = True

--- a/test/Parsing/ArgsTests.hs
+++ b/test/Parsing/ArgsTests.hs
@@ -5,16 +5,16 @@ import Parsing.Args
 import Test.Tasty
 import Test.Tasty.HUnit
 
-parseArgsTest :: [String] -> ParsedArgs -> String-> TestTree
-parseArgsTest arr restest testName = testCase testName $ do
-    res <- parseArgs' arr 0 (ParsedArgs False "")
-    restest @=? res
+-- parseArgsTest :: [String] -> ParsedArgs -> String-> TestTree
+-- parseArgsTest arr restest testName = testCase testName $ do
+--     res <- parseArgs' arr 0 (ParsedArgs False "")
+--     restest @=? res
 
-argsSuite :: TestTree
-argsSuite = testGroup "Parsing.Args Test Suite" [
-        parseArgsTest ["binaryName", "", ""] (ParsedArgs False "") "Empty Args",
-        parseArgsTest ["binaryName"] (ParsedArgs False "") "No Args",
-        parseArgsTest ["binaryName", "-h"] (ParsedArgs True "") "Only -h",
-        parseArgsTest ["binaryName", "filename"] (ParsedArgs False "filename") "Only filename",
-        parseArgsTest ["binaryName", "filename", "-h"] (ParsedArgs True "filename") "File with -h"
-    ]
+-- argsSuite :: TestTree
+-- argsSuite = testGroup "Parsing.Args Test Suite" [
+--         parseArgsTest ["binaryName", "", ""] (ParsedArgs False "") "Empty Args",
+--         parseArgsTest ["binaryName"] (ParsedArgs False "") "No Args",
+--         parseArgsTest ["binaryName", "-h"] (ParsedArgs True "") "Only -h",
+--         parseArgsTest ["binaryName", "filename"] (ParsedArgs False "filename") "Only filename",
+--         parseArgsTest ["binaryName", "filename", "-h"] (ParsedArgs True "filename") "File with -h"
+--     ]


### PR DESCRIPTION
Resolves #27 

Adds arg parsing and corresponding tests
also adds a makefile with argument support:
`make ARGS="--file=test.scm"`